### PR TITLE
Add group option

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (hwm, lwm, group) {
       _cb = null
       if(ended && ended !== true) cb(ended)
       else if(buffer.length) {
-        if (group) {
+        if(group) {
           var items = buffer
           buffer = []
           cb(null, items)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 
-module.exports = function (hwm, lwm) {
+module.exports = function (hwm, lwm, group) {
   hwm = hwm || 10
   lwm = lwm || 0
+  group = !!group
   var reading = false, ended = false, buffer = [], _cb = null
   return function (read) {
     function more () {
@@ -27,8 +28,13 @@ module.exports = function (hwm, lwm) {
 
       _cb = null
       if(ended && ended !== true) cb(ended)
-      else if(buffer.length) cb(null, buffer.shift())
-      else if(ended) cb(ended)
+      else if(buffer.length) {
+        if (group) {
+          var items = buffer
+          buffer = []
+          cb(null, items)
+        } else cb(null, buffer.shift())
+      } else if(ended) cb(ended)
       else _cb = cb
     }
 


### PR DESCRIPTION
Use case: gather many items, and process them in variable-size groups (where the consumer may take a variable amount of time), without substantially slowing down the producer. For instance, gather groups for batch database operations.

If there's a better way to handle this in the existing pull-stream ecosystem, I'm all ears.