### PR TITLE
Add group option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ pull(
 )
 ```
 
-## HighWatermark(hwm, lwm) => through
+## HighWatermark(hwm, lwm[, group]) => through
 
 read ahead at most to the high water mark (`hwm`) and at least to the low water mark (`lwm`)
 `hwm` default to 10, and `lwm` defaults to 0.
+
+the `group` option indicates that the buffer should be emitted wholesale as an
+array. this allows consumers to run batch operations on values, while avoiding
+slowing down the upstream producer. defaults to `false`.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 
-module.exports = function (hwm, lwm) {
+module.exports = function (hwm, lwm, group) {
   hwm = hwm || 10
   lwm = lwm || 0
+  group = !!group
   var reading = false, ended = false, buffer = [], _cb = null
   return function (read) {
     function more () {
-      if(reading || ended || buffer.length > hwm) return
+      if(reading || ended || buffer.length >= hwm) return
       reading = true
       read(null, function next (end, data) {
         if(end) ended = end
@@ -27,8 +28,13 @@ module.exports = function (hwm, lwm) {
 
       _cb = null
       if(ended && ended !== true) cb(ended)
-      else if(buffer.length) cb(null, buffer.shift())
-      else if(ended) cb(ended)
+      else if(buffer.length) {
+        if(group) {
+          var items = buffer
+          buffer = []
+          cb(null, items)
+        } else cb(null, buffer.shift())
+      } else if(ended) cb(ended)
       else _cb = cb
     }
 


### PR DESCRIPTION
Use case: gather many items, and process them in variable-size groups (where the consumer may take a variable amount of time), without substantially slowing down the producer. For instance, gather groups for batch database operations.

If there's a better way to handle this in the existing pull-stream ecosystem, I'm all ears.

Ended up making slightly breaking behavior to avoid an off-by-one error - `group` indicates it shouldn't receive more than `hwm` values.